### PR TITLE
Setup GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: './'
+      - id: deploy
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- add workflow for automatically deploying to GitHub Pages on every push to `main`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e67243ae4832b863613a3ed2f7303