### PR TITLE
Add JSON file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a simple web application that allows you to load exam q
 ## Usage
 
 1. Open `index.html` in a web browser.
-2. Paste a JSON array of question objects into the textarea. Each question should follow this structure:
+2. Select a JSON file containing an array of question objects using the file picker. Each question should follow this structure:
 
 ```json
 [

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 <h1>Exam App</h1>
 <div id="setup">
 <h2>Load Questions</h2>
-<p>Paste JSON of questions:</p>
-<textarea id="questionInput" rows="10" cols="50"></textarea><br>
+<p>Select JSON file of questions:</p>
+<input type="file" id="fileInput" accept=".json"><br>
 <button id="startBtn">Start Exam</button>
 </div>
 <div id="exam" style="display:none;">

--- a/script.js
+++ b/script.js
@@ -8,20 +8,31 @@ const questionContainer = document.getElementById('questionContainer');
 const resultDiv = document.getElementById('result');
 const scoreP = document.getElementById('score');
 const wrongDiv = document.getElementById('wrongAnswers');
+const fileInput = document.getElementById('fileInput');
 
 document.getElementById('startBtn').onclick = () => {
- try {
-   questions = JSON.parse(document.getElementById('questionInput').value);
-   if (!Array.isArray(questions)) throw new Error('Invalid format');
-   setupDiv.style.display = 'none';
-   examDiv.style.display = 'block';
-   currentQuestion = 0;
-   wrong = [];
-   correctCount = 0;
-   showQuestion();
- } catch (err) {
-   alert('Could not parse questions: ' + err.message);
+ const file = fileInput.files[0];
+ if (!file) {
+   alert('Please select a JSON file.');
+   return;
  }
+ const reader = new FileReader();
+ reader.onload = () => {
+   try {
+     questions = JSON.parse(reader.result);
+     if (!Array.isArray(questions)) throw new Error('Invalid format');
+     setupDiv.style.display = 'none';
+     examDiv.style.display = 'block';
+     currentQuestion = 0;
+     wrong = [];
+     correctCount = 0;
+     showQuestion();
+   } catch (err) {
+     alert('Could not parse questions: ' + err.message);
+   }
+ };
+ reader.onerror = () => alert('Error reading file.');
+ reader.readAsText(file);
 };
 
 document.getElementById('nextBtn').onclick = () => {
@@ -47,7 +58,7 @@ document.getElementById('nextBtn').onclick = () => {
 document.getElementById('restartBtn').onclick = () => {
  resultDiv.style.display = 'none';
  setupDiv.style.display = 'block';
- document.getElementById('questionInput').value = '';
+ fileInput.value = '';
 };
 
 function showQuestion() {


### PR DESCRIPTION
## Summary
- allow users to select a JSON file of questions
- update start logic to read the file using `FileReader`
- reset file input on restart
- document new workflow for loading a file

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_686e7346f4d8832b8126afd6376266bf